### PR TITLE
Various improvements

### DIFF
--- a/+logging/logging.m
+++ b/+logging/logging.m
@@ -36,6 +36,10 @@ classdef logging < handle
   properties (SetAccess=immutable)
       level_numbers;
   end
+  
+  properties
+      datefmt;
+  end
 
   properties (SetAccess=protected)
     name;
@@ -137,7 +141,7 @@ classdef logging < handle
     function writeLog(self, level, caller, message)
       level = self.getLevelNumber(level);
       if self.commandWindowLevel <= level || self.logLevel <= level
-        timestamp = datestr(now, 'yyyy-mm-dd HH:MM:SS,FFF');
+        timestamp = datestr(now, self.datefmt);
         levelStr = logging.logging.levels(level);
         logline = sprintf(self.logfmt, caller, timestamp, levelStr, message);
       end
@@ -155,6 +159,15 @@ classdef logging < handle
         fprintf(self.logfid, logline);
       end
     end        
+    
+    function set.datefmt(self, fmt)
+        try
+            datestr(now(), fmt);
+        catch
+            error('Invalid date format');
+        end
+        self.datefmt = fmt;
+    end
   end
   
   methods (Hidden)

--- a/+logging/logging.m
+++ b/+logging/logging.m
@@ -35,6 +35,7 @@ classdef logging < handle
   
   properties (SetAccess=immutable)
       level_numbers;
+      level_range;
   end
 
   properties (SetAccess=protected)
@@ -134,8 +135,10 @@ classdef logging < handle
       else
         self.logLevel_ = logging.logging.OFF;
       end
+      levelkeys = self.levels.keys;
       self.level_numbers = containers.Map(...
-          self.levels.values, self.levels.keys);
+          self.levels.values, levelkeys);
+      self.level_range = [min(levelkeys), max(levelkeys)];
     end
 
     function delete(self)
@@ -204,8 +207,8 @@ classdef logging < handle
   
   methods (Hidden)
     function level = getLevelNumber(self, level)
-      if logging.logging.levels.isKey(level)
-        % We don't need to do anything here
+      if isinteger(level) && self.level_range(1) <= level && level <= self.level_range(2)
+        return
       elseif self.level_numbers.isKey(level)
         level = self.level_numbers(level);
       else

--- a/+logging/logging.m
+++ b/+logging/logging.m
@@ -79,7 +79,11 @@ classdef logging < handle
     end
 
     function setLogLevel(self, level)
-      self.logLevel = self.getLevelNumber(level);
+      level = self.getLevelNumber(level);
+      if level > logging.logging.OFF && self.fid < 0
+          error('Cannot enable file logging without valid logfile');
+      end
+      self.logLevel = level;
     end
 
     function trace(self, message)

--- a/+logging/logging.m
+++ b/+logging/logging.m
@@ -210,10 +210,8 @@ classdef logging < handle
     function level = getLevelNumber(self, level)
       if isinteger(level) && self.level_range(1) <= level && level <= self.level_range(2)
         return
-      elseif self.level_numbers.isKey(level)
-        level = self.level_numbers(level);
       else
-        error('Invalid log level');
+        level = self.level_numbers(level);
       end
     end
   end

--- a/+logging/logging.m
+++ b/+logging/logging.m
@@ -34,8 +34,8 @@ classdef logging < handle
   end
   
   properties (SetAccess=immutable)
-      level_numbers;
-      level_range;
+    level_numbers;
+    level_range;
   end
 
   properties (SetAccess=protected)
@@ -48,15 +48,15 @@ classdef logging < handle
   end
 
   properties (Hidden,SetAccess=protected)
-      datefmt_ = 'yyyy-mm-dd HH:MM:SS,FFF';
-      logLevel_ = logging.logging.INFO;
-      commandWindowLevel_ = logging.logging.INFO;
+    datefmt_ = 'yyyy-mm-dd HH:MM:SS,FFF';
+    logLevel_ = logging.logging.INFO;
+    commandWindowLevel_ = logging.logging.INFO;
   end
   
   properties (Dependent)
-      datefmt;
-      logLevel;
-      commandWindowLevel;
+    datefmt;
+    logLevel;
+    commandWindowLevel;
   end
 
   methods(Static)
@@ -171,28 +171,28 @@ classdef logging < handle
     end        
     
     function set.datefmt(self, fmt)
-        try
-            datestr(now(), fmt);
-        catch
-            error('Invalid date format');
-        end
-        self.datefmt_ = fmt;
+      try
+        datestr(now(), fmt);
+      catch
+        error('Invalid date format');
+      end
+      self.datefmt_ = fmt;
     end
 
     function fmt = get.datefmt(self)
-        fmt = self.datefmt_;
+      fmt = self.datefmt_;
     end
     
     function set.logLevel(self, level)
       level = self.getLevelNumber(level);
       if level > logging.logging.OFF && self.logfid < 0
-          error('Cannot enable file logging without valid logfile');
+        error('Cannot enable file logging without valid logfile');
       end
       self.logLevel_ = level;
     end
     
     function level = get.logLevel(self)
-        level = self.logLevel_;
+      level = self.logLevel_;
     end
     
     function set.commandWindowLevel(self, level)
@@ -200,7 +200,7 @@ classdef logging < handle
     end
     
     function level = get.commandWindowLevel(self)
-        level = self.commandWindowLevel_;
+      level = self.commandWindowLevel_;
     end
         
         

--- a/+logging/logging.m
+++ b/+logging/logging.m
@@ -36,10 +36,6 @@ classdef logging < handle
   properties (SetAccess=immutable)
       level_numbers;
   end
-  
-  properties
-      datefmt = 'yyyy-mm-dd HH:MM:SS,FFF';
-  end
 
   properties (SetAccess=protected)
     name;
@@ -51,11 +47,13 @@ classdef logging < handle
   end
 
   properties (Hidden,SetAccess=protected)
+      datefmt_ = 'yyyy-mm-dd HH:MM:SS,FFF';
       logLevel_ = logging.logging.INFO;
       commandWindowLevel_ = logging.logging.INFO;
   end
   
   properties (Dependent)
+      datefmt;
       logLevel;
       commandWindowLevel;
   end
@@ -149,7 +147,7 @@ classdef logging < handle
     function writeLog(self, level, caller, message)
       level = self.getLevelNumber(level);
       if self.commandWindowLevel_ <= level || self.logLevel_ <= level
-        timestamp = datestr(now, self.datefmt);
+        timestamp = datestr(now, self.datefmt_);
         levelStr = logging.logging.levels(level);
         logline = sprintf(self.logfmt, caller, timestamp, levelStr, message);
       end
@@ -174,7 +172,11 @@ classdef logging < handle
         catch
             error('Invalid date format');
         end
-        self.datefmt = fmt;
+        self.datefmt_ = fmt;
+    end
+
+    function fmt = get.datefmt(self)
+        fmt = self.datefmt_;
     end
     
     function set.logLevel(self, level)

--- a/+logging/logging.m
+++ b/+logging/logging.m
@@ -38,7 +38,7 @@ classdef logging < handle
   end
   
   properties
-      datefmt;
+      datefmt = 'yyyy-mm-dd HH:MM:SS,FFF';
   end
 
   properties (SetAccess=protected)

--- a/+logging/logging.m
+++ b/+logging/logging.m
@@ -138,6 +138,7 @@ classdef logging < handle
       levelkeys = self.levels.keys;
       self.level_numbers = containers.Map(...
           self.levels.values, levelkeys);
+      levelkeys = cell2mat(self.levels.keys);
       self.level_range = [min(levelkeys), max(levelkeys)];
     end
 

--- a/+logging/logging.m
+++ b/+logging/logging.m
@@ -208,6 +208,15 @@ classdef logging < handle
   
   methods (Hidden)
     function level = getLevelNumber(self, level)
+    % LEVEL = GETLEVELNUMBER(LEVEL)
+    %
+    % Converts charecter-based level names to level numbers
+    % used internally by logging.
+    %
+    % If given a number, it makes sure the number is valid
+    % then returns it unchanged.
+    %
+    % This allows users to specify levels by name or number.
       if isinteger(level) && self.level_range(1) <= level && level <= self.level_range(2)
         return
       else

--- a/+logging/logging.m
+++ b/+logging/logging.m
@@ -133,7 +133,7 @@ classdef logging < handle
     end
 
     function delete(self)
-      if self.logLevel < logging.logging.OFF
+      if self.logfid < 0
         fclose(self.logfid);
       end
     end

--- a/README.md
+++ b/README.md
@@ -52,6 +52,44 @@ to log output at different levels:
   This level is used for non-critical errors that can endanger correctness.
 * `logger.critical(string)`: output `string` at level CRITICAL
   This level is used for critical errors that definitely endanger correctness.
+  
+The following utility methods are also available:
+
+* `logger.setFileName(string)`: set the log file to `string`.
+  This can be used to specify or change the file logs are saved to.
+* `logger.setCommandWindowLevel(level)`: set the command window log level to `level`.
+  Only log entries with a level greater than or equal to `level` will be displayed.
+  `level` can either be a string or an integer.
+* `logger.setLogLevel(level)`: set the file log level to `level`.
+  Only log entries with a level greater than or equal to `level` will be saved.
+  `level` can either be a string or an integer.
+  Note that even if the level is changed, nothing will be written if a valid
+  filename has not been set for the log.
+
+The following properties can be read or written:
+
+* `logger.datefmt`: the date/time format string.
+  This contains the date/time format string used by the logs.
+  The format must be compatible with the built-in `datestr` function.
+* `logger.commandWindowLevel`: the command window log level.
+  Only log entries with a level greater than or equal to `level` will be displayed.
+  It can be set with either a string or an integer, but will always return an integer.
+* `logger.logLevel`: the file log level.
+  Only log entries with a level greater than or equal to `level` will be saved.
+  It can be set with either a string or an integer, but will always return an integer.
+
+The following properties are read-only (note that these are called in a different way):
+
+* `logging.logging.ALL`: The integer value for the `ALL` level (0).
+* `logging.logging.TRACE`: The integer value for the `TRACE` level (1).
+* `logging.logging.DEBUG`: The integer value for the `DEBUG` level (2).
+* `logging.logging.INFO`: The integer value for the `INFO` level (3).
+* `logging.logging.WARNING`: The integer value for the `WARNING` level (4).
+* `logging.logging.ERROR`: The integer value for the `ERROR` level (5).
+* `logging.logging.CRITICAL`: The integer value for the `CRITICAL` level (6).
+* `logging.logging.OFF`: The integer value for the `OFF` level (6).
+  Note that there is no corresponding write method for this level, 
+  so if this level is set no logging will take place.
 
 ## Examples
 


### PR DESCRIPTION
This pull request adds one bug fix and several features.  

First, it fixes a bug where if you start the logger with log file, set `logLevel` to 0, then delete the logger, the file won't be closed.

Second, it turns `logLevel` and `commandWindowLevel` into dependent properties.  This allows validation to be done on them when they are set.  All the methods access the values through real, hidden properties for performance reasons.  This includes making sure the level is valid, allowing specifying the level by name instead of just by number, and not allowing enabling file logging when a file hasn't been opened.

Third, it allows overriding the date format.  This also checks that the new date format is valid before setting it.
