### PR TITLE
Workaround for keeping file open

### DIFF
--- a/+logging/logging.m
+++ b/+logging/logging.m
@@ -143,7 +143,7 @@ classdef logging < handle
     end
 
     function delete(self)
-      if self.logfid < 0
+      if self.logfid > -1
         fclose(self.logfid);
       end
     end


### PR DESCRIPTION
Even after using "clear all" in matlab workspace, library keeps the logger files opened