### PR TITLE
Use `inputParser` for initialization

### DIFF
--- a/+logging/logging.m
+++ b/+logging/logging.m
@@ -119,22 +119,21 @@ classdef logging < handle
       self.writeLog(self.CRITICAL, caller_name, message);
     end
 
-    function self = logging(name, opts)
-      if ischar(name),
-        self.name = name;
-      else
-        error('Logger name must be a string');
-      end
-      if nargin > 1 && isfield(opts, 'path')
-        display(opts, 'opts')
-        if ischar(opts.path)
-          self.setFilename(opts.path);  % Opens the log file.
-        else
-          error('Logger logfile path must be a string');
-        end
+    function self = logging(name, varargin)      
+      p = inputParser();
+      p.addRequired('name', @ischar);
+      p.addParameter('path', '', @ischar);
+      p.parse(name, varargin{:});
+      r = p.Results; 
+      disp(r)
+      
+      self.name = r.name;   
+      if ~isempty(r.path)
+        self.setFilename(r.path);  % Opens the log file.
       else
         self.logLevel_ = logging.logging.OFF;
       end
+      
       levelkeys = self.levels.keys;
       self.level_numbers = containers.Map(...
           self.levels.values, levelkeys);

--- a/+logging/logging.m
+++ b/+logging/logging.m
@@ -119,26 +119,31 @@ classdef logging < handle
       self.writeLog(self.CRITICAL, caller_name, message);
     end
 
-    function self = logging(name, varargin)      
-      p = inputParser();
-      p.addRequired('name', @ischar);
-      p.addParameter('path', '', @ischar);
-      p.parse(name, varargin{:});
-      r = p.Results; 
-      disp(r)
-      
-      self.name = r.name;   
-      if ~isempty(r.path)
-        self.setFilename(r.path);  % Opens the log file.
-      else
-        self.logLevel_ = logging.logging.OFF;
-      end
-      
+    function self = logging(name, varargin)
       levelkeys = self.levels.keys;
       self.level_numbers = containers.Map(...
           self.levels.values, levelkeys);
       levelkeys = cell2mat(self.levels.keys);
       self.level_range = [min(levelkeys), max(levelkeys)];
+      
+      p = inputParser();
+      p.addRequired('name', @ischar);
+      p.addParameter('path', '', @ischar);
+      p.addParameter('logLevel', self.logLevel);
+      p.addParameter('commandWindowLevel', self.commandWindowLevel);
+      p.addParameter('datefmt', self.datefmt_);
+      p.parse(name, varargin{:});
+      r = p.Results; 
+      
+      self.name = r.name;
+      self.commandWindowLevel = r.commandWindowLevel;
+      self.datefmt = r.datefmt;
+      if ~isempty(r.path)
+        self.setFilename(r.path);  % Opens the log file.
+        self.logLevel = r.logLevel;
+      else
+        self.logLevel_ = logging.logging.OFF;
+      end
     end
 
     function delete(self)

--- a/README.md
+++ b/README.md
@@ -36,6 +36,28 @@ The format is as follows:
 
 ## API
 
+An instance of the `logging` class is created using the `logging.getLogger` function.
+The first argument for this function must be the name of the logger. Four additional
+optional arguments are also available.  These can either be provided as name/value
+pairs (such as `logger.getlogger(name, 'path', path)`) or as a struct where the
+field names are the names of the argument (such as logger.getlogger(name, struct('path', path)`).
+The available arguments are:
+
+* `path`: The path to the log file.  If this is not specified or is an empty string,
+  then logging to a file is disabled.
+  This must be a string.
+* `logLevel`: set the file log level.
+  Only log entries with a level greater than or equal to this level will be saved.
+  This can either be a string or an integer.
+  Note that this argument will be ignored if `path` is empty or not specified.
+* `commandWindowLevel`: set the command window log level.
+  Only log entries with a level greater than or equal to this level will be displayed.
+  This can either be a string or an integer.
+* `datefmt`: the date/time format string.
+  This contains the date/time format string used by the logs.
+  The format must be compatible with the built-in `datestr` function.
+  This must be a string.
+
 If `logger` is an instance of the `logging` class, the following methods can be used
 to log output at different levels:
 
@@ -114,7 +136,7 @@ A logger's assigned level for the command window (or terminal) can be changed:
 A logger can also output to file:
 
 ```matlab
->> logger2 = logging.getLogger('myotherlogger', struct('path', '/tmp/logger2.log'))
+>> logger2 = logging.getLogger('myotherlogger', 'path', '/tmp/logger2.log')
 >> logger.setLogLevel(logging.logging.WARNING)
 ```
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ An instance of the `logging` class is created using the `logging.getLogger` func
 The first argument for this function must be the name of the logger. Four additional
 optional arguments are also available.  These can either be provided as name/value
 pairs (such as `logger.getlogger(name, 'path', path)`) or as a struct where the
-field names are the names of the argument (such as logger.getlogger(name, struct('path', path)`).
+field names are the names of the argument (such as `logger.getlogger(name, struct('path', path)`).
 The available arguments are:
 
 * `path`: The path to the log file.  If this is not specified or is an empty string,


### PR DESCRIPTION
The MATLAB `inputParser` class makes it easier to have optional arguments in MATLAB.  This patch switches the class intialization method to use the `inputParser` class to handle optional arguments.  Since the `inputParser` class also accepts arguments as structs, this is fully backwards-compatible.  However, it also lets you specify arguments as name/value pairs.  

This patch also adds additional optional arguments and updates the README to reflect the changes.