### PR TITLE
improved runtime when cmd & file logging is off

### DIFF
--- a/+logging/clearLogger.m
+++ b/+logging/clearLogger.m
@@ -1,0 +1,5 @@
+function clearLogger(name)
+    [~, destructor] = logging.getLogger(name);
+    destructor();
+end
+

--- a/+logging/getLogger.m
+++ b/+logging/getLogger.m
@@ -18,7 +18,11 @@ function [obj, deleteLogger] = getLogger(name, varargin)
   deleteLogger = @() deleteLogInstance();
   
   function deleteLogInstance() 
-      delete(loggers);
-      clear('loggers');
+      if ~logger_found
+          error(['logger for file [ ' name ' ] not found'])
+      end
+      loggers = loggers(loggers ~= obj);
+      delete(obj);
+      clear('obj');
   end
 end

--- a/+logging/getLogger.m
+++ b/+logging/getLogger.m
@@ -1,4 +1,4 @@
-function obj = getLogger(name, varargin)
+function [obj, deleteLogger] = getLogger(name, varargin)
   persistent loggers;
   logger_found = false;
   if ~isempty(loggers)
@@ -13,5 +13,12 @@ function obj = getLogger(name, varargin)
   if ~logger_found
     obj = logging.logging(name, varargin{:});
     loggers = [loggers, obj];
+  end
+  
+  deleteLogger = @() deleteLogInstance();
+  
+  function deleteLogInstance() 
+      delete(loggers);
+      clear('loggers');
   end
 end

--- a/+logging/logging.m
+++ b/+logging/logging.m
@@ -88,33 +88,55 @@ classdef logging < handle
     function setLogLevel(self, level)
       self.logLevel = level;
     end
+    
+    function tf = ignoreLogging(self)
+        tf = self.logLevel + self.commandWindowLevel == 2*self.OFF;
+    end
 
     function trace(self, message)
+      if self.ignoreLogging()
+           return;
+      end
       [caller_name, ~] = self.getCallerInfo();
       self.writeLog(self.TRACE, caller_name, message);
     end
 
     function debug(self, message)
+      if self.ignoreLogging()
+           return;
+      end
       [caller_name, ~] = self.getCallerInfo();
       self.writeLog(self.DEBUG, caller_name, message);
     end
 
     function info(self, message)
+      if self.ignoreLogging()
+           return;
+      end
       [caller_name, ~] = self.getCallerInfo();
       self.writeLog(self.INFO, caller_name, message);
     end
 
     function warn(self, message)
+       if self.ignoreLogging()
+           return;
+       end
       [caller_name, ~] = self.getCallerInfo();
       self.writeLog(self.WARNING, caller_name, message);
     end
 
     function error(self, message)
+       if self.ignoreLogging()
+           return;
+       end
       [caller_name, ~] = self.getCallerInfo();
       self.writeLog(self.ERROR, caller_name, message);
     end
 
     function critical(self, message)
+       if self.ignoreLogging()
+           return;
+       end
       [caller_name, ~] = self.getCallerInfo();
       self.writeLog(self.CRITICAL, caller_name, message);
     end

--- a/+logging/logging.m
+++ b/+logging/logging.m
@@ -179,6 +179,10 @@ classdef logging < handle
       if self.commandWindowLevel_ <= level || self.logLevel_ <= level
         timestamp = datestr(now, self.datefmt_);
         levelStr = logging.logging.levels(level);
+        [rows, ~] = size(message);
+        if rows > 1
+            message = sprintf('\n %s', evalc('disp(message)'));
+        end
         logline = sprintf(self.logfmt, caller, timestamp, levelStr, message);
       end
 

--- a/+logging/logging.m
+++ b/+logging/logging.m
@@ -60,7 +60,13 @@ classdef logging < handle
   end
 
   methods(Static)
-    function [name, line] = getCallerInfo()
+    function [name, line] = getCallerInfo(self)
+      
+      if nargin > 0 && self.ignoreLogging()
+          name = [];
+          line = [];
+          return
+      end
       [ST, ~] = dbstack();
       offset = min(size(ST, 1), 3);
       name = ST(offset).name;
@@ -90,54 +96,36 @@ classdef logging < handle
     end
     
     function tf = ignoreLogging(self)
-        tf = self.logLevel + self.commandWindowLevel == 2*self.OFF;
+        tf = self.commandWindowLevel_ == logging.logging.OFF && self.logLevel_ == logging.logging.OFF;
     end
 
     function trace(self, message)
-      if self.ignoreLogging()
-           return;
-      end
-      [caller_name, ~] = self.getCallerInfo();
+      [caller_name, ~] = self.getCallerInfo(self);
       self.writeLog(self.TRACE, caller_name, message);
     end
 
     function debug(self, message)
-      if self.ignoreLogging()
-           return;
-      end
-      [caller_name, ~] = self.getCallerInfo();
+      [caller_name, ~] = self.getCallerInfo(self);
       self.writeLog(self.DEBUG, caller_name, message);
     end
 
     function info(self, message)
-      if self.ignoreLogging()
-           return;
-      end
-      [caller_name, ~] = self.getCallerInfo();
+      [caller_name, ~] = self.getCallerInfo(self);
       self.writeLog(self.INFO, caller_name, message);
     end
 
     function warn(self, message)
-       if self.ignoreLogging()
-           return;
-       end
-      [caller_name, ~] = self.getCallerInfo();
+      [caller_name, ~] = self.getCallerInfo(self);
       self.writeLog(self.WARNING, caller_name, message);
     end
 
     function error(self, message)
-       if self.ignoreLogging()
-           return;
-       end
-      [caller_name, ~] = self.getCallerInfo();
+      [caller_name, ~] = self.getCallerInfo(self);
       self.writeLog(self.ERROR, caller_name, message);
     end
 
     function critical(self, message)
-       if self.ignoreLogging()
-           return;
-       end
-      [caller_name, ~] = self.getCallerInfo();
+      [caller_name, ~] = self.getCallerInfo(self);
       self.writeLog(self.CRITICAL, caller_name, message);
     end
 

--- a/+logging/logging.m
+++ b/+logging/logging.m
@@ -96,7 +96,7 @@ classdef logging < handle
     end
     
     function tf = ignoreLogging(self)
-        tf = self.commandWindowLevel_ == logging.logging.OFF && self.logLevel_ == logging.logging.OFF;
+        tf = self.commandWindowLevel_ == self.OFF && self.logLevel_ == self.OFF;
     end
 
     function trace(self, message)

--- a/+logging/logging.m
+++ b/+logging/logging.m
@@ -167,11 +167,8 @@ classdef logging < handle
       if self.commandWindowLevel_ <= level || self.logLevel_ <= level
         timestamp = datestr(now, self.datefmt_);
         levelStr = logging.logging.levels(level);
-        [rows, ~] = size(message);
-        if rows > 1
-            message = sprintf('\n %s', evalc('disp(message)'));
-        end
-        logline = sprintf(self.logfmt, caller, timestamp, levelStr, message);
+       
+        logline = sprintf(self.logfmt, caller, timestamp, levelStr, self.getMessage(message));
       end
 
       if self.commandWindowLevel_ <= level
@@ -241,5 +238,17 @@ classdef logging < handle
         level = self.level_numbers(level);
       end
     end
-  end
+      
+    function message = getMessage(~, message)
+    
+      if isa(message, 'function_handle')
+        message = message();
+      end
+      [rows, ~] = size(message);
+      if rows > 1
+        message = sprintf('\n %s', evalc('disp(message)'));
+      end
+    end
+  
+ end
 end

--- a/+logging/testspeed.m
+++ b/+logging/testspeed.m
@@ -6,10 +6,10 @@ function testspeed(logPath)
   L.setCommandWindowLevel(L.TRACE);
   L.setLogLevel(L.OFF);
   tic;
-  for i=1:1e2
+  for i=1:1e3
     L.trace('test');
   end
-  disp('1e2 logs when logging only to command window');
+  disp('1e3 logs when logging only to command window');
   toc;
 
   L.setCommandWindowLevel(L.OFF);
@@ -24,9 +24,9 @@ function testspeed(logPath)
   L.setCommandWindowLevel(L.OFF);
   L.setLogLevel(L.TRACE);
   tic;
-  for i=1:1e2
+  for i=1:1e3
     L.trace('test');
   end
-  disp('1e2 logs when logging to file');
+  disp('1e3 logs when logging to file');
   toc;
 end

--- a/+logging/testspeed.m
+++ b/+logging/testspeed.m
@@ -29,4 +29,13 @@ function testspeed(logPath)
   end
   disp('1e3 logs when logging to file');
   toc;
+    L.setCommandWindowLevel(L.OFF);
+  L.setLogLevel(L.TRACE);
+  
+  tic;
+  for i=1:1e3
+    L.trace(@() 'test');
+  end
+  disp('1e3 logs when logging to file using function handle');
+  toc;
 end


### PR DESCRIPTION
Hi,

This pull request has,
- clean up handler in the getLogger function. 
- fixed the display of 2d char array message
- the code to avoid  `dbstack()` call when the command window logging and file logging is turned off. 

|	Task (1e3 lines)	   | previous elapsed time | current elapsed time |
|-----------------------------|-----------------------|----------------------|
| logging to command window | 3.363777		       | 3.133629
| logging is off		                   | **0.213782**		       | **0.011460**
| logging to file		           | 0.857700		       | 0.814813
