### PR TITLE
buffer messages before writing to file

### DIFF
--- a/+logging/logging.m
+++ b/+logging/logging.m
@@ -193,7 +193,7 @@ classdef logging < handle
       end
 
       if self.logLevel_ <= level && self.logfid > -1
-        self.bufferedMessages_(self.bufferCursor_) = logline;
+        self.bufferedMessages_{self.bufferCursor_} = logline;
         if self.bufferCursor_ == numel(self.bufferedMessages_)
           cellfun(@(x) fprintf(self.logfid, x), self.bufferedMessages_);
 	  self.bufferCursor_ = 1;
@@ -240,7 +240,7 @@ classdef logging < handle
       validateattributes(bufferSize, {'numeric'}, {'scalar', 'integer', 'nonzero', 'positive'});
       n = numel(self.bufferedMessages_);
       if bufferSize > n 
-        self.bufferedMessages_ = [self.bufferedMessages_ cell(bufferSize - n)];
+        self.bufferedMessages_ = [self.bufferedMessages_ cell(1, bufferSize - n)];
       else
         self.bufferedMessages_ = self.bufferedMessages_(1:bufferSize);
       end

--- a/+logging/logging.m
+++ b/+logging/logging.m
@@ -237,7 +237,7 @@ classdef logging < handle
     end
 
     function set.bufferingSize(self, bufferSize)
-      validateattribute(bufferSize, {'numeric'}, {'scalar', 'integer', 'nonzero', 'positive'});
+      validateattributes(bufferSize, {'numeric'}, {'scalar', 'integer', 'nonzero', 'positive'});
       n = numel(self.bufferedMessages_);
       if bufferSize > n 
         self.bufferedMessages_ = [self.bufferedMessages_ cell(bufferSize - n)];

--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ The available arguments are:
   This contains the date/time format string used by the logs.
   The format must be compatible with the built-in `datestr` function.
   This must be a string.
+* `bufferingSize` : set the number buffered logging lines berfore writing to file.
+  Must be a positive integer. 
 
 If `logger` is an instance of the `logging` class, the following methods can be used
 to log output at different levels:


### PR DESCRIPTION
Add two properties to the logging class
bufferMessages : The first is a cell array that contains messages to be
written.
bufferCursor_ is an integer that points to next cell to write in
bufferMessages_

During logging, messages are added to buffer. Once it's full, log lines
are written on file.

This new feature have no impact on logging on console.

A new method called setBufferingSize was created to change buffer size, on the model of the
others methods