### PR TITLE
Fixed backslash bug on file output

### DIFF
--- a/+logging/logging.m
+++ b/+logging/logging.m
@@ -184,7 +184,7 @@ classdef logging < handle
       end
 
       if self.logLevel_ <= level && self.logfid > -1
-        fprintf(self.logfid, logline);
+        fprintf(self.logfid, '%s', logline);
       end
     end        
     


### PR DESCRIPTION
When sending output to a file, `logline` is used as the format string in
`fprintf`.  If there are backslashes in the string (or other special characters), `fprintf`
breaks.

This commit fixes the problem, by formatting the log message with `%s`.