### PR TITLE
Instead of passing plain strings,now can pass arguments like sprintf

### DIFF
--- a/+logging/logging.m
+++ b/+logging/logging.m
@@ -167,16 +167,11 @@ classdef logging < handle
 
     function writeLog(self, level, caller, message, varargin)
         
-      if nargin > 4
-          message = sprintf(message, varargin{:});
-      end
-        
       level = self.getLevelNumber(level);
       if self.commandWindowLevel_ <= level || self.logLevel_ <= level
         timestamp = datestr(now, self.datefmt_);
         levelStr = logging.logging.levels(level);
-       
-        logline = sprintf(self.logfmt, caller, timestamp, levelStr, self.getMessage(message));
+        logline = sprintf(self.logfmt, caller, timestamp, levelStr, self.getMessage(message, varargin{:}));
       end
 
       if self.commandWindowLevel_ <= level
@@ -247,11 +242,16 @@ classdef logging < handle
       end
     end
       
-    function message = getMessage(~, message)
+    function message = getMessage(~, message, varargin)
     
       if isa(message, 'function_handle')
         message = message();
       end
+      
+      if nargin > 2
+        message = sprintf(message, varargin{:});
+      end
+      
       [rows, ~] = size(message);
       if rows > 1
         message = sprintf('\n %s', evalc('disp(message)'));

--- a/+logging/logging.m
+++ b/+logging/logging.m
@@ -99,34 +99,34 @@ classdef logging < handle
         tf = self.commandWindowLevel_ == self.OFF && self.logLevel_ == self.OFF;
     end
 
-    function trace(self, message)
+    function trace(self, varargin)
       [caller_name, ~] = self.getCallerInfo(self);
-      self.writeLog(self.TRACE, caller_name, message);
+      self.writeLog(self.TRACE, caller_name, varargin{:});
     end
 
-    function debug(self, message)
+    function debug(self, varargin)
       [caller_name, ~] = self.getCallerInfo(self);
-      self.writeLog(self.DEBUG, caller_name, message);
+      self.writeLog(self.DEBUG, caller_name, varargin{:});
     end
 
-    function info(self, message)
+    function info(self, varargin)
       [caller_name, ~] = self.getCallerInfo(self);
-      self.writeLog(self.INFO, caller_name, message);
+      self.writeLog(self.INFO, caller_name, varargin{:});
     end
 
-    function warn(self, message)
+    function warn(self, varargin)
       [caller_name, ~] = self.getCallerInfo(self);
-      self.writeLog(self.WARNING, caller_name, message);
+      self.writeLog(self.WARNING, caller_name, varargin{:});
     end
 
-    function error(self, message)
+    function error(self, varargin)
       [caller_name, ~] = self.getCallerInfo(self);
-      self.writeLog(self.ERROR, caller_name, message);
+      self.writeLog(self.ERROR, caller_name, varargin{:});
     end
 
-    function critical(self, message)
+    function critical(self, varargin)
       [caller_name, ~] = self.getCallerInfo(self);
-      self.writeLog(self.CRITICAL, caller_name, message);
+      self.writeLog(self.CRITICAL, caller_name, varargin{:});
     end
 
     function self = logging(name, varargin)
@@ -165,7 +165,12 @@ classdef logging < handle
       end
     end
 
-    function writeLog(self, level, caller, message)
+    function writeLog(self, level, caller, message, varargin)
+        
+      if nargin > 4
+          message = sprintf(message, varargin{:});
+      end
+        
       level = self.getLevelNumber(level);
       if self.commandWindowLevel_ <= level || self.logLevel_ <= level
         timestamp = datestr(now, self.datefmt_);

--- a/README.md
+++ b/README.md
@@ -162,4 +162,4 @@ Output to either the command window or a file can be suppressed with `logging.lo
 
 # Tests
 
-Invoke `runtests(test)` in a MATLAB prompt to run the unit tests.
+Invoke `runtests('test')` in a MATLAB prompt to run the unit tests.

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ to log output at different levels:
   
 The following utility methods are also available:
 
-* `logger.setFileName(string)`: set the log file to `string`.
+* `logger.setFilename(string)`: set the log file to `string`.
   This can be used to specify or change the file logs are saved to.
 * `logger.setCommandWindowLevel(level)`: set the command window log level to `level`.
   Only log entries with a level greater than or equal to `level` will be displayed.
@@ -127,6 +127,13 @@ logging.info 2016-09-14 15:10:06,049 INFO     life is just peachy
 logging.critical 2016-09-14 15:12:37,652 CRITICAL run away!
 ```
 
+Use formatting for logged messages similar to `sprintf` or `fprintf`
+
+```matlab
+>> logger.critical('Item %d (%s) not found', 217, 'foo');
+logging.critical 2016-09-14 15:12:37,652 CRITICAL Item 217 (foo) not found
+```
+
 A logger's assigned level for the command window (or terminal) can be changed:
 
 ```matlab
@@ -152,3 +159,7 @@ Output to either the command window or a file can be suppressed with `logging.lo
    Currently, no, but feel free to submit a pull request!
 3. *Can I change the format string used by loggers?*
    Currently, no, but feel free to submit a pull request!
+
+# Tests
+
+Invoke `runtests(test)` in a MATLAB prompt to run the unit tests.

--- a/test/loggingTest.m
+++ b/test/loggingTest.m
@@ -39,13 +39,7 @@ classdef (SharedTestFixtures={ ...
                 'Hello world 2');
         end
         
-        function testLoggingWithVariableNumberOfInputs(testCase)
-            % Warning: this test does not check the actual outputs logging
-            % prints using fprintf. However, the test would fail if any
-            % error occurs, so is still useful and can be used for manual
-            % verification. TODO log in a file so that we can automatically
-            % test.
-            
+        function testLoggingWithVariableNumberOfInputs(testCase)            
             logfile_name = [testCase.logger_name '.log'];
                         
             testCase.l.setFilename(logfile_name);

--- a/test/loggingTest.m
+++ b/test/loggingTest.m
@@ -1,0 +1,85 @@
+classdef (SharedTestFixtures={ ...
+        matlab.unittest.fixtures.PathFixture('..'),...
+        matlab.unittest.fixtures.WorkingFolderFixture}) ...
+    loggingTest < matlab.unittest.TestCase
+    %LOGGINGTEST unit tests for the logging class
+    % Adding parent folder to path
+    % Changing working directory to a temporary folder since we may
+    % create files
+    
+    properties
+        l; % instance of logging.logging
+        logger_name = 'testVariableMessages';
+        logging_methods = {@trace, @debug, @info, @warn, @error, @critical}
+    end
+    
+    methods(TestMethodSetup)
+        function createFigure(testCase)
+            testCase.l = logging.getLogger(testCase.logger_name);
+        end
+    end
+ 
+    methods(TestMethodTeardown)
+        function closeFigure(testCase)
+            % loggers can be persistent. Delete logger so that tests are
+            % independent
+            logging.clearLogger(testCase.logger_name);
+        end
+    end
+    
+    methods (Test)
+        
+        function testGetMessageWithVariableNumberOfInputs(testCase)            
+            testCase.verifyEqual(testCase.l.getMessage('Hello'), 'Hello');
+            
+            testCase.verifyEqual(testCase.l.getMessage('Hello %s', 'world'),...
+                'Hello world');
+            
+            testCase.verifyEqual(testCase.l.getMessage('Hello %s %d', 'world', 2),...
+                'Hello world 2');
+        end
+        
+        function testLoggingWithVariableNumberOfInputs(testCase)
+            % Warning: this test does not check the actual outputs logging
+            % prints using fprintf. However, the test would fail if any
+            % error occurs, so is still useful and can be used for manual
+            % verification. TODO log in a file so that we can automatically
+            % test.
+            
+            logfile_name = [testCase.logger_name '.log'];
+                        
+            testCase.l.setFilename(logfile_name);
+            testCase.l.setLogLevel(logging.logging.CRITICAL);
+            
+            for i=1:length(testCase.logging_methods)
+                method_to_test = testCase.logging_methods{i};
+                method_to_test(testCase.l, 'Hello');
+                method_to_test(testCase.l, 'Hello %s', 'world');
+                method_to_test(testCase.l, '%d', 2);
+            end
+            
+            % For each of the logged lines, only retrive the logged message
+            loggedStrings = loggingTest.getLogMessagesFromFile(logfile_name,...
+                '^.* CRITICAL (?<t0>.*)$');
+            
+            testCase.verifyEqual(loggedStrings, {...
+                'Hello', 'Hello world', '2'});
+            
+        end
+        
+    end
+    
+    methods(Static = true)
+        function ret = getLogMessagesFromFile(fileName, token)
+            lines = strsplit(fileread(fileName), '\n');
+            
+            % Last line is a empty new line.
+            ret = regexp(lines(1:end-1), token, 'names');
+            
+            % Only the ``t0'' token is required.
+            ret = cellfun(@(p)p.t0, ret, 'UniformOutput', false);
+        end
+    end
+    
+end
+


### PR DESCRIPTION
These changes facilitate passing multiple arguments to logging methods (e.g. `logging.info` or `logging.error`) like this:

  loggingob.info('My name is %s and id is %d', 'Shafiul', 13)

Previously, we would have to create the string by first calling sprintf.
 
